### PR TITLE
Add drag-and-drop builder and ESP32 Arduino library

### DIFF
--- a/arduino/README.md
+++ b/arduino/README.md
@@ -1,0 +1,23 @@
+# ZiLink Arduino Library
+
+Simple Arduino library for ESP32 devices to connect to the ZiLink platform using a token.
+
+## Usage
+
+```cpp
+#include <ZiLinkClient.h>
+
+ZiLinkClient client("your.server.com", 8080);
+
+void setup() {
+  client.begin("WiFiSSID", "WiFiPassword");
+  client.connect("YOUR_ACCESS_TOKEN");
+}
+
+void loop() {
+  client.loop();
+  // Example: send sensor data every 10 seconds
+  client.sendSensorData("device-1", "{\\"temperature\\":25}");
+  delay(10000);
+}
+```

--- a/arduino/ZiLinkClient/ZiLinkClient.cpp
+++ b/arduino/ZiLinkClient/ZiLinkClient.cpp
@@ -1,0 +1,31 @@
+#include "ZiLinkClient.h"
+
+ZiLinkClient::ZiLinkClient(const char* host, uint16_t port) : host(host), port(port) {}
+
+void ZiLinkClient::begin(const char* ssid, const char* password) {
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+}
+
+void ZiLinkClient::connect(const String& token) {
+  authToken = token;
+  ws.begin(host, port, "/");
+  ws.onEvent([this](WStype_t type, uint8_t* payload, size_t length) {
+    if (type == WStype_CONNECTED) {
+      String msg = "{\"type\":\"auth\",\"token\":\"" + authToken + "\"}";
+      ws.sendTXT(msg);
+    }
+  });
+}
+
+void ZiLinkClient::loop() {
+  ws.loop();
+}
+
+void ZiLinkClient::sendSensorData(const String& deviceId, const String& payload) {
+  String msg = "{\"type\":\"data\",\"deviceId\":\"" + deviceId + "\",\"payload\":" + payload + "}";
+  ws.sendTXT(msg);
+}
+

--- a/arduino/ZiLinkClient/ZiLinkClient.h
+++ b/arduino/ZiLinkClient/ZiLinkClient.h
@@ -1,0 +1,24 @@
+#ifndef ZILINKCLIENT_H
+#define ZILINKCLIENT_H
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <WebSocketsClient.h>
+
+class ZiLinkClient {
+public:
+  ZiLinkClient(const char* host, uint16_t port);
+  void begin(const char* ssid, const char* password);
+  void connect(const String& token);
+  void loop();
+  void sendSensorData(const String& deviceId, const String& payload);
+
+private:
+  WebSocketsClient ws;
+  const char* host;
+  uint16_t port;
+  String authToken;
+};
+
+#endif // ZILINKCLIENT_H
+

--- a/arduino/ZiLinkClient/library.properties
+++ b/arduino/ZiLinkClient/library.properties
@@ -1,0 +1,9 @@
+name=ZiLinkClient
+version=0.1.0
+author=ZiLink
+maintainer=ZiLink <support@zilink.local>
+sentence=Connect ESP32 devices to the ZiLink platform using a token.
+paragraph=Provides a minimal WebSocket-based client for authenticating with the ZiLink platform.
+category=Communication
+url=https://example.com
+architectures=esp32

--- a/client/src/app/builder/page.jsx
+++ b/client/src/app/builder/page.jsx
@@ -1,0 +1,69 @@
+"use client";
+
+import React, { useState } from "react";
+
+/**
+ * Simple drag and drop builder page.
+ * Users can drag components from a sidebar into the main canvas area.
+ */
+const availableComponents = [
+	{ type: "button", label: "Button" },
+	{ type: "text", label: "Text" },
+];
+
+export default function BuilderPage() {
+	const [items, setItems] = useState([]);
+
+	/**
+	 * Handle dropping a component onto the canvas.
+	 * @param {React.DragEvent<HTMLDivElement>} e
+	 */
+	const handleDrop = (e) => {
+		e.preventDefault();
+		const type = e.dataTransfer.getData("component-type");
+		const comp = availableComponents.find((c) => c.type === type);
+		if (comp) {
+			setItems((prev) => [...prev, { ...comp, id: Date.now() }]);
+		}
+	};
+
+	/**
+	 * Handle starting a drag for a component.
+	 * @param {React.DragEvent<HTMLDivElement>} e
+	 * @param {string} type
+	 */
+	const handleDragStart = (e, type) => {
+		e.dataTransfer.setData("component-type", type);
+	};
+
+	return (
+		<div className='flex h-screen'>
+			<aside className='w-64 bg-gray-100 p-4 space-y-2'>
+				{availableComponents.map((c) => (
+					<div
+						key={c.type}
+						draggable
+						onDragStart={(e) => handleDragStart(e, c.type)}
+						className='p-2 bg-white rounded shadow cursor-move'>
+						{c.label}
+					</div>
+				))}
+			</aside>
+			<main
+				className='flex-1 p-4 bg-gray-50'
+				onDrop={handleDrop}
+				onDragOver={(e) => e.preventDefault()}>
+				<div className='h-full border-2 border-dashed border-gray-300 rounded-lg'>
+					{items.map((item) => (
+						<div
+							key={item.id}
+							className='m-2'>
+							{item.type === "button" && <button className='px-4 py-2 bg-blue-500 text-white rounded'>Button</button>}
+							{item.type === "text" && <p className='text-gray-700'>Text</p>}
+						</div>
+					))}
+				</div>
+			</main>
+		</div>
+	);
+}

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
 		"start": "concurrently \"npm run start:server\" \"npm run start:client\"",
 		"start:server": "cd server && npm start",
 		"start:client": "cd client && npm start",
-		"check": "prettier --ignore-path .gitignore --check .",
-		"format": "prettier --ignore-path .gitignore --write ."
+		"check": "prettier --ignore-unknown --ignore-path .gitignore --check .",
+		"format": "prettier --ignore-unknown --ignore-path .gitignore --write ."
 	},
 	"keywords": [
 		"iot",


### PR DESCRIPTION
## Summary
- add simple drag-and-drop builder page for composing UI components
- introduce Arduino ESP32 client library for token-based connection
- adjust prettier scripts to skip unknown file types

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`
- `cd client && npm run lint` *(fails: ESLint couldn't find the config "next/javascript")*

------
https://chatgpt.com/codex/tasks/task_e_68b06e912cac8320bf9a777e592b69fb