### PR TITLE
Redirect authenticated users and add landing page

### DIFF
--- a/client/src/app/login/page.jsx
+++ b/client/src/app/login/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
@@ -15,8 +15,14 @@ const LoginPage = () => {
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	const [isLoading, setIsLoading] = useState(false);
-	const { login, isLoading: authLoading } = useAuth();
+	const { login, isLoading: authLoading, isAuthenticated } = useAuth();
+	const router = useRouter();
 
+	useEffect(() => {
+		if (!authLoading && isAuthenticated) {
+			router.replace("/dashboard");
+		}
+	}, [authLoading, isAuthenticated, router]);
 	/**
 	 * Handle email login form submission
 	 * @param {React.FormEvent} e

--- a/client/src/app/page.jsx
+++ b/client/src/app/page.jsx
@@ -1,46 +1,32 @@
 "use client";
 
-import { useEffect } from "react";
+import Link from "next/link";
 import { useAuth } from "@/contexts/AuthContext";
-import { useRouter } from "next/navigation";
 
 export default function Home() {
-	const { isAuthenticated, isLoading } = useAuth();
-	const router = useRouter();
+	const { isAuthenticated } = useAuth();
 
-	useEffect(() => {
-		if (!isLoading) {
-			if (isAuthenticated) {
-				router.push("/dashboard");
-			} else {
-				router.push("/login");
-			}
-		}
-	}, [isAuthenticated, isLoading, router]);
-
-	// Show loading while checking auth status
 	return (
-		<div className='min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100'>
-			<div className='text-center'>
-				<div className='w-16 h-16 bg-blue-600 rounded-lg flex items-center justify-center mx-auto mb-4'>
-					<svg
-						className='w-10 h-10 text-white'
-						fill='none'
-						stroke='currentColor'
-						viewBox='0 0 24 24'
-						xmlns='http://www.w3.org/2000/svg'>
-						<path
-							strokeLinecap='round'
-							strokeLinejoin='round'
-							strokeWidth={2}
-							d='M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z'
-						/>
-					</svg>
+		<div className='min-h-screen flex items-center justify-center bg-gradient-to-br from-indigo-600 via-purple-600 to-pink-600 text-white'>
+			<div className='text-center space-y-6 px-4'>
+				<h1 className='text-5xl font-extrabold tracking-tight sm:text-6xl'>ZiLink IoT Platform</h1>
+				<p className='text-xl max-w-2xl mx-auto'>
+					Unleash the power of your connected devices with a modern and intuitive dashboard.
+				</p>
+				<div className='flex justify-center space-x-4'>
+					{isAuthenticated ?
+						<Link
+							href='/dashboard'
+							className='px-8 py-3 bg-white text-indigo-600 font-semibold rounded-lg shadow-lg hover:bg-gray-100 transition-colors'>
+							Go to Dashboard
+						</Link>
+					:	<Link
+							href='/login'
+							className='px-8 py-3 bg-white text-indigo-600 font-semibold rounded-lg shadow-lg hover:bg-gray-100 transition-colors'>
+							Login
+						</Link>
+					}
 				</div>
-				<h1 className='text-4xl font-bold text-gray-900 mb-2'>ZiLink IoT Platform</h1>
-				<p className='text-gray-600 mb-8'>Connecting the Internet of Things</p>
-
-				{isLoading && <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto'></div>}
 			</div>
 		</div>
 	);

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -37,38 +37,38 @@ app.use(limiter);
 // CORS configuration
 // Allow multiple origins via env (comma-separated) and default local dev
 const rawAllowed = [
-  process.env.CLIENT_URLS,
-  process.env.CLIENT_URL,
-  "http://localhost:3000",
-  "http://127.0.0.1:3000",
-  "https://ziji.world",
+	process.env.CLIENT_URLS,
+	process.env.CLIENT_URL,
+	"http://localhost:3000",
+	"http://127.0.0.1:3000",
+	"https://ziji.world",
 ].filter(Boolean);
 
 const allowedOrigins = rawAllowed
-  .flatMap((v) => v.split(","))
-  .map((v) => v.trim())
-  .filter((v) => v.length > 0);
+	.flatMap((v) => v.split(","))
+	.map((v) => v.trim())
+	.filter((v) => v.length > 0);
 
 const corsOptions = {
-  origin: (origin, callback) => {
-    // Allow non-browser or same-origin requests (no Origin header)
-    if (!origin) return callback(null, true);
+	origin: (origin, callback) => {
+		// Allow non-browser or same-origin requests (no Origin header)
+		if (!origin) return callback(null, true);
 
-    // Exact match against allowed origins
-    if (allowedOrigins.includes(origin)) return callback(null, true);
+		// Exact match against allowed origins
+		if (allowedOrigins.includes(origin)) return callback(null, true);
 
-    // Optionally allow subdomains of ziji.world
-    try {
-      const url = new URL(origin);
-      if (url.hostname.endsWith(".ziji.world")) return callback(null, true);
-    } catch (_) {}
+		// Optionally allow subdomains of ziji.world
+		try {
+			const url = new URL(origin);
+			if (url.hostname.endsWith(".ziji.world")) return callback(null, true);
+		} catch (_) {}
 
-    return callback(new Error(`Not allowed by CORS: ${origin}`));
-  },
-  credentials: true,
-  methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-  allowedHeaders: ["Content-Type", "Authorization"],
-  optionsSuccessStatus: 204,
+		return callback(new Error(`Not allowed by CORS: ${origin}`));
+	},
+	credentials: true,
+	methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+	allowedHeaders: ["Content-Type", "Authorization"],
+	optionsSuccessStatus: 204,
 };
 
 app.use(cors(corsOptions));


### PR DESCRIPTION
## Summary
- Redirect logged-in users away from the login page to the dashboard
- Add a new colorful landing page with login or dashboard button
- Format server entry file to satisfy prettier

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b0dda92624832095c078edd0545602