### PR TITLE
Add sign-up page and improve dark mode styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 ZiLink là một platform quản lý thiết bị IoT toàn diện được xây dựng với Node.js, Express, WebSocket, Next.js, và MongoDB. Platform
 hỗ trợ real-time data monitoring, device management, và OAuth authentication.
 
+> [!NOTE] Đọc kỹ tài liệu cài đặt trước khi bắt đầu làm việc với ZiLink.
+
+> [!IMPORTANT] Cần cài đặt Node.js 18+ và cấu hình đúng file `.env` để hệ thống chạy ổn định.
+
+> [!WARNING] Không commit các thông tin nhạy cảm như Device Token hoặc file `.env` lên repository công khai.
+
 ![ZiLink Architecture](docs/architecture-diagram.png)
 
 ## 🚀 Tính Năng

--- a/README.md
+++ b/README.md
@@ -3,13 +3,8 @@
 ZiLink là một platform quản lý thiết bị IoT toàn diện được xây dựng với Node.js, Express, WebSocket, Next.js, và MongoDB. Platform
 hỗ trợ real-time data monitoring, device management, và OAuth authentication.
 
-> [!NOTE] Đọc kỹ tài liệu cài đặt trước khi bắt đầu làm việc với ZiLink.
-
-> [!IMPORTANT] Cần cài đặt Node.js 18+ và cấu hình đúng file `.env` để hệ thống chạy ổn định.
-
-> [!WARNING] Không commit các thông tin nhạy cảm như Device Token hoặc file `.env` lên repository công khai.
-
-![ZiLink Architecture](docs/architecture-diagram.png)
+![ZiLink Architecture](![thumnail](https://github.com/user-attachments/assets/0ed2c124-0a40-46f5-b17d-477c22a66d7a)
+)
 
 ## 🚀 Tính Năng
 

--- a/client/src/app/auth/callback/page.jsx
+++ b/client/src/app/auth/callback/page.jsx
@@ -56,7 +56,7 @@ function OAuthCallbackContent() {
 
 			// Redirect to login after a delay
 			setTimeout(() => {
-				router.push("/login?error=oauth_failed");
+				router.push("/auth/login?error=oauth_failed");
 			}, 3000);
 		}
 	}, [searchParams, router]);

--- a/client/src/app/auth/login/page.jsx
+++ b/client/src/app/auth/login/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
@@ -15,8 +15,14 @@ const LoginPage = () => {
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	const [isLoading, setIsLoading] = useState(false);
-	const { login, isLoading: authLoading } = useAuth();
+	const { login, isLoading: authLoading, isAuthenticated } = useAuth();
+	const router = useRouter();
 
+	useEffect(() => {
+		if (!authLoading && isAuthenticated) {
+			router.replace("/dashboard");
+		}
+	}, [authLoading, isAuthenticated, router]);
 	/**
 	 * Handle email login form submission
 	 * @param {React.FormEvent} e
@@ -32,6 +38,7 @@ const LoginPage = () => {
 		try {
 			setIsLoading(true);
 			await login(email, password);
+			router.replace("/dashboard");
 		} catch (error) {
 			const errorMessage = error?.response?.data?.message || "Login failed";
 			console.error("Login error:", error);
@@ -52,14 +59,14 @@ const LoginPage = () => {
 
 	if (authLoading) {
 		return (
-			<div className='min-h-screen flex items-center justify-center bg-gray-50'>
+			<div className='min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900'>
 				<div className='animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600'></div>
 			</div>
 		);
 	}
 
 	return (
-		<div className='min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8'>
+		<div className='min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8'>
 			<div className='max-w-md w-full space-y-8'>
 				<div>
 					<div className='flex justify-center'>
@@ -79,16 +86,16 @@ const LoginPage = () => {
 							</svg>
 						</div>
 					</div>
-					<h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900'>Sign in to ZiLink</h2>
-					<p className='mt-2 text-center text-sm text-gray-600'>Manage your IoT devices with ease</p>
+					<h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-gray-100'>Sign in to ZiLink</h2>
+					<p className='mt-2 text-center text-sm text-gray-600 dark:text-gray-400'>Manage your IoT devices with ease</p>
 				</div>
 
-				<div className='bg-white py-8 px-6 shadow-xl rounded-lg sm:px-10'>
+				<div className='bg-white dark:bg-gray-800 py-8 px-6 shadow-xl rounded-lg sm:px-10'>
 					{/* OAuth Login Buttons */}
 					<div className='space-y-3'>
 						<button
 							onClick={() => handleOAuthLogin("google")}
-							className='w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 transition duration-200'>
+							className='w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 transition duration-200 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'>
 							<svg
 								className='w-5 h-5 mr-3'
 								viewBox='0 0 24 24'>
@@ -114,7 +121,7 @@ const LoginPage = () => {
 
 						<button
 							onClick={() => handleOAuthLogin("github")}
-							className='w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 transition duration-200'>
+							className='w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 transition duration-200 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'>
 							<svg
 								className='w-5 h-5 mr-3'
 								fill='currentColor'
@@ -126,7 +133,7 @@ const LoginPage = () => {
 
 						<button
 							onClick={() => handleOAuthLogin("discord")}
-							className='w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 transition duration-200'>
+							className='w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 transition duration-200 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'>
 							<svg
 								className='w-5 h-5 mr-3'
 								fill='currentColor'
@@ -167,7 +174,7 @@ const LoginPage = () => {
 									required
 									value={email}
 									onChange={(e) => setEmail(e.target.value)}
-									className='appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm'
+									className='appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-300 dark:text-gray-100'
 									placeholder='Enter your email'
 								/>
 							</div>
@@ -188,7 +195,7 @@ const LoginPage = () => {
 									required
 									value={password}
 									onChange={(e) => setPassword(e.target.value)}
-									className='appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm'
+									className='appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-300 dark:text-gray-100'
 									placeholder='Enter your password'
 								/>
 							</div>
@@ -208,10 +215,10 @@ const LoginPage = () => {
 
 					<div className='mt-6'>
 						<div className='text-center'>
-							<span className='text-sm text-gray-600'>
+							<span className='text-sm text-gray-600 dark:text-gray-400'>
 								Don't have an account?{" "}
 								<Link
-									href='/register'
+									href='/auth/sign-up'
 									className='font-medium text-blue-600 hover:text-blue-500 transition duration-200'>
 									Sign up
 								</Link>
@@ -221,7 +228,7 @@ const LoginPage = () => {
 				</div>
 
 				<div className='text-center'>
-					<p className='text-xs text-gray-500'>
+					<p className='text-xs text-gray-500 dark:text-gray-400'>
 						By signing in, you agree to our{" "}
 						<Link
 							href='/terms'

--- a/client/src/app/auth/sign-up/page.jsx
+++ b/client/src/app/auth/sign-up/page.jsx
@@ -1,0 +1,298 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { toast } from "react-hot-toast";
+import apiService from "@/lib/api";
+
+/**
+ * Sign up page component
+ * @returns {React.JSX.Element}
+ */
+const SignUpPage = () => {
+	const [name, setName] = useState("");
+	const [email, setEmail] = useState("");
+	const [password, setPassword] = useState("");
+	const [confirmPassword, setConfirmPassword] = useState("");
+	const [isLoading, setIsLoading] = useState(false);
+	const { register, isLoading: authLoading, isAuthenticated } = useAuth();
+	const router = useRouter();
+
+	useEffect(() => {
+		if (!authLoading && isAuthenticated) {
+			router.replace("/dashboard");
+		}
+	}, [authLoading, isAuthenticated, router]);
+
+	/**
+	 * Handle email registration form submission
+	 * @param {React.FormEvent} e
+	 */
+	const handleEmailRegister = async (e) => {
+		e.preventDefault();
+
+		if (!name || !email || !password || !confirmPassword) {
+			toast.error("Please fill in all fields");
+			return;
+		}
+		if (password !== confirmPassword) {
+			toast.error("Passwords do not match");
+			return;
+		}
+
+		try {
+			setIsLoading(true);
+			await register(email, password, name);
+			router.replace("/dashboard");
+		} catch (error) {
+			const errorMessage = error?.response?.data?.message || "Registration failed";
+			console.error("Registration error:", error);
+			toast.error(errorMessage);
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	/**
+	 * Handle OAuth login
+	 * @param {"google" | "github" | "discord"} provider
+	 */
+	const handleOAuthLogin = (provider) => {
+		const oauthUrl = apiService.getOAuthUrl(provider);
+		window.location.href = oauthUrl;
+	};
+
+	if (authLoading) {
+		return (
+			<div className='min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900'>
+				<div className='animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600'></div>
+			</div>
+		);
+	}
+
+	return (
+		<div className='min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8'>
+			<div className='max-w-md w-full space-y-8'>
+				<div>
+					<div className='flex justify-center'>
+						<div className='w-16 h-16 bg-blue-600 rounded-lg flex items-center justify-center'>
+							<svg
+								className='w-10 h-10 text-white'
+								fill='none'
+								stroke='currentColor'
+								viewBox='0 0 24 24'
+								xmlns='http://www.w3.org/2000/svg'>
+								<path
+									strokeLinecap='round'
+									strokeLinejoin='round'
+									strokeWidth={2}
+									d='M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z'
+								/>
+							</svg>
+						</div>
+					</div>
+					<h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-gray-100'>Create your account</h2>
+					<p className='mt-2 text-center text-sm text-gray-600 dark:text-gray-400'>Start your journey with ZiLink</p>
+				</div>
+
+				<div className='bg-white dark:bg-gray-800 py-8 px-6 shadow-xl rounded-lg sm:px-10'>
+					{/* OAuth Sign Up Buttons */}
+					<div className='space-y-3'>
+						<button
+							onClick={() => handleOAuthLogin("google")}
+							className='w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 transition duration-200 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'>
+							<svg
+								className='w-5 h-5 mr-3'
+								viewBox='0 0 24 24'>
+								<path
+									fill='currentColor'
+									d='M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z'
+								/>
+								<path
+									fill='currentColor'
+									d='M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z'
+								/>
+								<path
+									fill='currentColor'
+									d='M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z'
+								/>
+								<path
+									fill='currentColor'
+									d='M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z'
+								/>
+							</svg>
+							Continue with Google
+						</button>
+
+						<button
+							onClick={() => handleOAuthLogin("github")}
+							className='w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 transition duration-200 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'>
+							<svg
+								className='w-5 h-5 mr-3'
+								fill='currentColor'
+								viewBox='0 0 24 24'>
+								<path d='M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z' />
+							</svg>
+							Continue with GitHub
+						</button>
+
+						<button
+							onClick={() => handleOAuthLogin("discord")}
+							className='w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 transition duration-200 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'>
+							<svg
+								className='w-5 h-5 mr-3'
+								fill='currentColor'
+								viewBox='0 0 24 24'>
+								<path d='M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.197.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z' />
+							</svg>
+							Continue with Discord
+						</button>
+					</div>
+
+					<div className='mt-6'>
+						<div className='relative'>
+							<div className='absolute inset-0 flex items-center'>
+								<div className='w-full border-t border-gray-300' />
+							</div>
+							<div className='relative flex justify-center text-sm'>
+								<span className='px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400'>Or continue with email</span>
+							</div>
+						</div>
+					</div>
+
+					{/* Email Registration Form */}
+					<form
+						className='mt-6 space-y-6'
+						onSubmit={handleEmailRegister}>
+						<div>
+							<label
+								htmlFor='name'
+								className='block text-sm font-medium text-gray-700 dark:text-gray-300'>
+								Name
+							</label>
+							<div className='mt-1'>
+								<input
+									id='name'
+									name='name'
+									type='text'
+									required
+									value={name}
+									onChange={(e) => setName(e.target.value)}
+									className='appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-300 dark:text-gray-100'
+									placeholder='Enter your name'
+								/>
+							</div>
+						</div>
+
+						<div>
+							<label
+								htmlFor='email'
+								className='block text-sm font-medium text-gray-700 dark:text-gray-300'>
+								Email address
+							</label>
+							<div className='mt-1'>
+								<input
+									id='email'
+									name='email'
+									type='email'
+									autoComplete='email'
+									required
+									value={email}
+									onChange={(e) => setEmail(e.target.value)}
+									className='appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-300 dark:text-gray-100'
+									placeholder='Enter your email'
+								/>
+							</div>
+						</div>
+
+						<div>
+							<label
+								htmlFor='password'
+								className='block text-sm font-medium text-gray-700 dark:text-gray-300'>
+								Password
+							</label>
+							<div className='mt-1'>
+								<input
+									id='password'
+									name='password'
+									type='password'
+									autoComplete='new-password'
+									required
+									value={password}
+									onChange={(e) => setPassword(e.target.value)}
+									className='appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-300 dark:text-gray-100'
+									placeholder='Enter your password'
+								/>
+							</div>
+						</div>
+
+						<div>
+							<label
+								htmlFor='confirmPassword'
+								className='block text-sm font-medium text-gray-700 dark:text-gray-300'>
+								Confirm Password
+							</label>
+							<div className='mt-1'>
+								<input
+									id='confirmPassword'
+									name='confirmPassword'
+									type='password'
+									required
+									value={confirmPassword}
+									onChange={(e) => setConfirmPassword(e.target.value)}
+									className='appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-300 dark:text-gray-100'
+									placeholder='Confirm your password'
+								/>
+							</div>
+						</div>
+
+						<div>
+							<button
+								type='submit'
+								disabled={isLoading}
+								className='group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition duration-200'>
+								{isLoading ?
+									<div className='w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin'></div>
+								:	"Create account"}
+							</button>
+						</div>
+					</form>
+
+					<div className='mt-6'>
+						<div className='text-center'>
+							<span className='text-sm text-gray-600 dark:text-gray-400'>
+								Already have an account?{" "}
+								<Link
+									href='/auth/login'
+									className='font-medium text-blue-600 hover:text-blue-500 transition duration-200'>
+									Sign in
+								</Link>
+							</span>
+						</div>
+					</div>
+				</div>
+
+				<div className='text-center'>
+					<p className='text-xs text-gray-500 dark:text-gray-400'>
+						By signing up, you agree to our{" "}
+						<Link
+							href='/terms'
+							className='text-blue-600 hover:text-blue-500'>
+							Terms of Service
+						</Link>{" "}
+						and{" "}
+						<Link
+							href='/privacy'
+							className='text-blue-600 hover:text-blue-500'>
+							Privacy Policy
+						</Link>
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default SignUpPage;

--- a/client/src/app/dashboard/page.jsx
+++ b/client/src/app/dashboard/page.jsx
@@ -38,7 +38,7 @@ const DashboardPage = () => {
 
 	useEffect(() => {
 		if (!authLoading && !isAuthenticated) {
-			router.push("/login");
+			router.push("/auth/login");
 			return;
 		}
 

--- a/client/src/app/layout.jsx
+++ b/client/src/app/layout.jsx
@@ -1,8 +1,8 @@
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/contexts/AuthContext";
-import { Toaster } from "react-hot-toast";
 import ThemeToggle from "@/components/ThemeToggle";
+import ToastProvider from "@/components/ui/toaster";
 
 const geistSans = Geist({
 	variable: "--font-geist-sans",
@@ -33,16 +33,7 @@ export default function RootLayout({ children }) {
 				<AuthProvider>
 					<ThemeToggle />
 					{children}
-					<Toaster
-						position='top-right'
-						toastOptions={{
-							duration: 4000,
-							style: {
-								background: "#363636",
-								color: "#fff",
-							},
-						}}
-					/>
+					<ToastProvider />
 				</AuthProvider>
 			</body>
 		</html>

--- a/client/src/app/page.jsx
+++ b/client/src/app/page.jsx
@@ -1,47 +1,201 @@
-"use client";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ArrowRight, Zap, Shield, BarChart3, Smartphone, Globe, Users } from "lucide-react";
 
-import { useEffect } from "react";
-import { useAuth } from "@/contexts/AuthContext";
-import { useRouter } from "next/navigation";
-
-export default function Home() {
-	const { isAuthenticated, isLoading } = useAuth();
-	const router = useRouter();
-
-	useEffect(() => {
-		if (!isLoading) {
-			if (isAuthenticated) {
-				router.push("/dashboard");
-			} else {
-				router.push("/login");
-			}
-		}
-	}, [isAuthenticated, isLoading, router]);
-
-	// Show loading while checking auth status
+export default function HomePage() {
 	return (
-		<div className='min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100'>
-			<div className='text-center'>
-				<div className='w-16 h-16 bg-blue-600 rounded-lg flex items-center justify-center mx-auto mb-4'>
-					<svg
-						className='w-10 h-10 text-white'
-						fill='none'
-						stroke='currentColor'
-						viewBox='0 0 24 24'
-						xmlns='http://www.w3.org/2000/svg'>
-						<path
-							strokeLinecap='round'
-							strokeLinejoin='round'
-							strokeWidth={2}
-							d='M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z'
-						/>
-					</svg>
+		<div className='min-h-screen bg-gradient-to-br from-blue-50 via-white to-cyan-50 dark:from-gray-900 dark:via-gray-950 dark:to-gray-900'>
+			{/* Navigation */}
+			<nav className='border-b bg-white/80 backdrop-blur-sm sticky top-0 z-50 dark:bg-gray-900/80 dark:border-gray-700'>
+				<div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
+					<div className='flex justify-between items-center h-16'>
+						<div className='flex items-center space-x-2'>
+							<div className='w-8 h-8 bg-gradient-to-r from-blue-600 to-cyan-600 rounded-lg flex items-center justify-center'>
+								<Zap className='w-5 h-5 text-white' />
+							</div>
+							<span className='text-xl font-bold bg-gradient-to-r from-blue-600 to-cyan-600 bg-clip-text text-transparent'>
+								ZiLink
+							</span>
+						</div>
+						<div className='flex items-center space-x-4'>
+							<Link href='/auth/login'>
+								<Button variant='ghost'>Sign In</Button>
+							</Link>
+							<Link href='/auth/sign-up'>
+								<Button className='bg-gradient-to-r from-blue-600 to-cyan-600 hover:from-blue-700 hover:to-cyan-700'>
+									Get Started
+								</Button>
+							</Link>
+						</div>
+					</div>
 				</div>
-				<h1 className='text-4xl font-bold text-gray-900 mb-2'>ZiLink IoT Platform</h1>
-				<p className='text-gray-600 mb-8'>Connecting the Internet of Things</p>
+			</nav>
 
-				{isLoading && <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto'></div>}
-			</div>
+			{/* Hero Section */}
+			<section className='relative overflow-hidden py-20 sm:py-32'>
+				<div className='absolute inset-0 bg-gradient-to-r from-blue-600/10 to-cyan-600/10 dark:from-blue-600/20 dark:to-cyan-600/20' />
+				<div className='relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
+					<div className='text-center'>
+						<Badge className='mb-6 bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900 dark:text-blue-100 dark:hover:bg-blue-800'>
+							Next-Gen IoT Platform
+						</Badge>
+						<h1 className='text-4xl sm:text-6xl font-bold text-gray-900 dark:text-gray-100 mb-6'>
+							Connect Your World with{" "}
+							<span className='bg-gradient-to-r from-blue-600 to-cyan-600 bg-clip-text text-transparent'>ZiLink</span>
+						</h1>
+						<p className='text-xl text-gray-600 dark:text-gray-300 mb-8 max-w-3xl mx-auto'>
+							The ultimate IoT platform for monitoring, controlling, and analyzing your smart devices. Build custom dashboards,
+							get real-time insights, and scale your IoT infrastructure effortlessly.
+						</p>
+						<div className='flex flex-col sm:flex-row gap-4 justify-center'>
+							<Link href='/auth/sign-up'>
+								<Button
+									size='lg'
+									className='bg-gradient-to-r from-blue-600 to-cyan-600 hover:from-blue-700 hover:to-cyan-700'>
+									Start Building <ArrowRight className='ml-2 w-4 h-4' />
+								</Button>
+							</Link>
+							<Link href='/auth/login'>
+								<Button
+									size='lg'
+									variant='outline'>
+									View Dashboard
+								</Button>
+							</Link>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			{/* Features Grid */}
+			<section className='py-20 bg-white dark:bg-gray-900'>
+				<div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
+					<div className='text-center mb-16'>
+						<h2 className='text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4'>Everything You Need for IoT Success</h2>
+						<p className='text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto'>
+							Powerful features designed to make IoT development and management simple, scalable, and secure.
+						</p>
+					</div>
+
+					<div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8'>
+						<Card className='border-0 shadow-lg hover:shadow-xl transition-shadow duration-300'>
+							<CardContent className='p-6'>
+								<div className='w-12 h-12 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-lg flex items-center justify-center mb-4'>
+									<BarChart3 className='w-6 h-6 text-white' />
+								</div>
+								<h3 className='text-xl font-semibold mb-2 dark:text-gray-100'>Real-time Analytics</h3>
+								<p className='text-gray-600 dark:text-gray-300'>
+									Monitor your devices with live charts, custom metrics, and intelligent alerts.
+								</p>
+							</CardContent>
+						</Card>
+
+						<Card className='border-0 shadow-lg hover:shadow-xl transition-shadow duration-300'>
+							<CardContent className='p-6'>
+								<div className='w-12 h-12 bg-gradient-to-r from-purple-500 to-pink-500 rounded-lg flex items-center justify-center mb-4'>
+									<Smartphone className='w-6 h-6 text-white' />
+								</div>
+								<h3 className='text-xl font-semibold mb-2 dark:text-gray-100'>Custom Dashboards</h3>
+								<p className='text-gray-600 dark:text-gray-300'>
+									Build personalized dashboards with drag-and-drop widgets tailored to your needs.
+								</p>
+							</CardContent>
+						</Card>
+
+						<Card className='border-0 shadow-lg hover:shadow-xl transition-shadow duration-300'>
+							<CardContent className='p-6'>
+								<div className='w-12 h-12 bg-gradient-to-r from-green-500 to-emerald-500 rounded-lg flex items-center justify-center mb-4'>
+									<Shield className='w-6 h-6 text-white' />
+								</div>
+								<h3 className='text-xl font-semibold mb-2 dark:text-gray-100'>Enterprise Security</h3>
+								<p className='text-gray-600 dark:text-gray-300'>
+									Bank-level security with OAuth integration, encrypted connections, and access controls.
+								</p>
+							</CardContent>
+						</Card>
+
+						<Card className='border-0 shadow-lg hover:shadow-xl transition-shadow duration-300'>
+							<CardContent className='p-6'>
+								<div className='w-12 h-12 bg-gradient-to-r from-orange-500 to-red-500 rounded-lg flex items-center justify-center mb-4'>
+									<Globe className='w-6 h-6 text-white' />
+								</div>
+								<h3 className='text-xl font-semibold mb-2 dark:text-gray-100'>Global Connectivity</h3>
+								<p className='text-gray-600 dark:text-gray-300'>
+									Connect devices worldwide with our reliable, low-latency global infrastructure.
+								</p>
+							</CardContent>
+						</Card>
+
+						<Card className='border-0 shadow-lg hover:shadow-xl transition-shadow duration-300'>
+							<CardContent className='p-6'>
+								<div className='w-12 h-12 bg-gradient-to-r from-indigo-500 to-purple-500 rounded-lg flex items-center justify-center mb-4'>
+									<Users className='w-6 h-6 text-white' />
+								</div>
+								<h3 className='text-xl font-semibold mb-2 dark:text-gray-100'>Team Collaboration</h3>
+								<p className='text-gray-600 dark:text-gray-300'>
+									Share dashboards, manage permissions, and collaborate with your team seamlessly.
+								</p>
+							</CardContent>
+						</Card>
+
+						<Card className='border-0 shadow-lg hover:shadow-xl transition-shadow duration-300'>
+							<CardContent className='p-6'>
+								<div className='w-12 h-12 bg-gradient-to-r from-teal-500 to-cyan-500 rounded-lg flex items-center justify-center mb-4'>
+									<Zap className='w-6 h-6 text-white' />
+								</div>
+								<h3 className='text-xl font-semibold mb-2 dark:text-gray-100'>Lightning Fast</h3>
+								<p className='text-gray-600 dark:text-gray-300'>
+									Optimized for speed with real-time updates and instant device responses.
+								</p>
+							</CardContent>
+						</Card>
+					</div>
+				</div>
+			</section>
+
+			{/* CTA Section */}
+			<section className='py-20 bg-gradient-to-r from-blue-600 to-cyan-600'>
+				<div className='max-w-4xl mx-auto text-center px-4 sm:px-6 lg:px-8'>
+					<h2 className='text-3xl font-bold text-white mb-4'>Ready to Transform Your IoT Experience?</h2>
+					<p className='text-xl text-blue-100 mb-8'>
+						Join thousands of developers and businesses building the future with ZiLink.
+					</p>
+					<div className='flex flex-col sm:flex-row gap-4 justify-center'>
+						<Link href='/auth/sign-up'>
+							<Button
+								size='lg'
+								className='bg-white text-blue-600 hover:bg-gray-100'>
+								Start Free Trial
+							</Button>
+						</Link>
+						<Link href='/auth/login'>
+							<Button
+								size='lg'
+								variant='outline'
+								className='border-white text-white hover:bg-white/10 bg-transparent'>
+								Sign In to Dashboard
+							</Button>
+						</Link>
+					</div>
+				</div>
+			</section>
+
+			{/* Footer */}
+			<footer className='bg-gray-900 dark:bg-gray-950 text-white py-12'>
+				<div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
+					<div className='flex flex-col md:flex-row justify-between items-center'>
+						<div className='flex items-center space-x-2 mb-4 md:mb-0'>
+							<div className='w-8 h-8 bg-gradient-to-r from-blue-600 to-cyan-600 rounded-lg flex items-center justify-center'>
+								<Zap className='w-5 h-5 text-white' />
+							</div>
+							<span className='text-xl font-bold'>ZiLink</span>
+						</div>
+						<p className='text-gray-400 dark:text-gray-500'>© 2024 ZiLink. Built with ❤️ for the IoT community.</p>
+					</div>
+				</div>
+			</footer>
 		</div>
 	);
 }

--- a/client/src/components/ui/badge.jsx
+++ b/client/src/components/ui/badge.jsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Badge({ className, ...props }) {
+	return (
+		<span
+			className={cn("inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold", className)}
+			{...props}
+		/>
+	);
+}
+
+export { Badge };

--- a/client/src/components/ui/button.jsx
+++ b/client/src/components/ui/button.jsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = {
+	default: "bg-blue-600 text-white hover:bg-blue-700",
+	outline:
+		"border border-gray-300 text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800",
+	ghost: "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800",
+};
+
+const buttonSizes = {
+	default: "h-10 px-4 py-2",
+	lg: "h-12 px-6",
+	sm: "h-8 px-3",
+};
+
+const Button = React.forwardRef(({ className, variant = "default", size = "default", ...props }, ref) => {
+	return (
+		<button
+			ref={ref}
+			className={cn(
+				"inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none",
+				buttonVariants[variant],
+				buttonSizes[size],
+				className,
+			)}
+			{...props}
+		/>
+	);
+});
+Button.displayName = "Button";
+
+export { Button };

--- a/client/src/components/ui/card.jsx
+++ b/client/src/components/ui/card.jsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef(({ className, ...props }, ref) => (
+	<div
+		ref={ref}
+		className={cn(
+			"rounded-xl border bg-white text-gray-900 shadow dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700",
+			className,
+		)}
+		{...props}
+	/>
+));
+Card.displayName = "Card";
+
+const CardContent = React.forwardRef(({ className, ...props }, ref) => (
+	<div
+		ref={ref}
+		className={cn("p-6", className)}
+		{...props}
+	/>
+));
+CardContent.displayName = "CardContent";
+
+export { Card, CardContent };

--- a/client/src/components/ui/toaster.jsx
+++ b/client/src/components/ui/toaster.jsx
@@ -1,0 +1,24 @@
+import { Toaster } from "react-hot-toast";
+
+/**
+ * Global toast provider with modern styling
+ */
+export default function ToastProvider() {
+	return (
+		<Toaster
+			position='top-right'
+			gutter={8}
+			toastOptions={{
+				duration: 4000,
+				className:
+					"rounded-xl bg-white/90 dark:bg-gray-900/90 text-gray-900 dark:text-gray-100 shadow-lg border border-gray-200 dark:border-gray-800 backdrop-blur-md",
+				success: {
+					className: "border-l-4 border-green-500 bg-green-50 dark:bg-green-900/40 text-green-800 dark:text-green-100", // tailwind
+				},
+				error: {
+					className: "border-l-4 border-red-500 bg-red-50 dark:bg-red-900/40 text-red-800 dark:text-red-100",
+				},
+			}}
+		/>
+	);
+}

--- a/client/src/contexts/AuthContext.jsx
+++ b/client/src/contexts/AuthContext.jsx
@@ -134,7 +134,7 @@ export const AuthProvider = ({ children }) => {
 			await apiService.logout();
 			websocketService.disconnect();
 			setUser(null);
-			router.push("/login");
+			router.push("/auth/login");
 		} catch (error) {
 			console.error("Logout failed:", error);
 		} finally {

--- a/client/src/lib/api.js
+++ b/client/src/lib/api.js
@@ -142,7 +142,7 @@ class ApiService {
 						return this.api(originalRequest);
 					} catch (refreshError) {
 						this.logout();
-						window.location.href = "/login";
+						window.location.href = "/auth/login";
 						return Promise.reject(refreshError);
 					}
 				}

--- a/client/src/lib/utils.js
+++ b/client/src/lib/utils.js
@@ -1,0 +1,6 @@
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs) {
+	return twMerge(clsx(...inputs));
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -37,38 +37,38 @@ app.use(limiter);
 // CORS configuration
 // Allow multiple origins via env (comma-separated) and default local dev
 const rawAllowed = [
-  process.env.CLIENT_URLS,
-  process.env.CLIENT_URL,
-  "http://localhost:3000",
-  "http://127.0.0.1:3000",
-  "https://ziji.world",
+	process.env.CLIENT_URLS,
+	process.env.CLIENT_URL,
+	"http://localhost:3000",
+	"http://127.0.0.1:3000",
+	"https://ziji.world",
 ].filter(Boolean);
 
 const allowedOrigins = rawAllowed
-  .flatMap((v) => v.split(","))
-  .map((v) => v.trim())
-  .filter((v) => v.length > 0);
+	.flatMap((v) => v.split(","))
+	.map((v) => v.trim())
+	.filter((v) => v.length > 0);
 
 const corsOptions = {
-  origin: (origin, callback) => {
-    // Allow non-browser or same-origin requests (no Origin header)
-    if (!origin) return callback(null, true);
+	origin: (origin, callback) => {
+		// Allow non-browser or same-origin requests (no Origin header)
+		if (!origin) return callback(null, true);
 
-    // Exact match against allowed origins
-    if (allowedOrigins.includes(origin)) return callback(null, true);
+		// Exact match against allowed origins
+		if (allowedOrigins.includes(origin)) return callback(null, true);
 
-    // Optionally allow subdomains of ziji.world
-    try {
-      const url = new URL(origin);
-      if (url.hostname.endsWith(".ziji.world")) return callback(null, true);
-    } catch (_) {}
+		// Optionally allow subdomains of ziji.world
+		try {
+			const url = new URL(origin);
+			if (url.hostname.endsWith(".ziji.world")) return callback(null, true);
+		} catch (_) {}
 
-    return callback(new Error(`Not allowed by CORS: ${origin}`));
-  },
-  credentials: true,
-  methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-  allowedHeaders: ["Content-Type", "Authorization"],
-  optionsSuccessStatus: 204,
+		return callback(new Error(`Not allowed by CORS: ${origin}`));
+	},
+	credentials: true,
+	methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+	allowedHeaders: ["Content-Type", "Authorization"],
+	optionsSuccessStatus: 204,
 };
 
 app.use(cors(corsOptions));


### PR DESCRIPTION
## Summary
- Introduce `/auth/sign-up` page with OAuth buttons, email registration, and dashboard redirect when already authenticated
- Update login and landing pages plus shared Button/Card components to respect light and dark themes
- Fix login links to point at the new sign-up route
- Provide a modern toast provider with rounded, translucent styles for success and error messages

## Testing
- `npm run check`
- `npm run build` *(fails: Failed to fetch `Geist` fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dda92624832095c078edd0545602