### PR TITLE
feat: animate theme toggle

### DIFF
--- a/client/src/app/console/page.jsx
+++ b/client/src/app/console/page.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import ThemeToggle from "@/components/ThemeToggle";
 import websocketService from "@/lib/websocket";
 
 export default function ConsolePage() {
@@ -33,7 +32,6 @@ export default function ConsolePage() {
 
 	return (
 		<div className='min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-4'>
-			<ThemeToggle />
 			<h1 className='text-2xl font-bold mb-4'>Raw Console</h1>
 			<div className='bg-gray-100 dark:bg-gray-800 rounded p-4 h-[80vh] overflow-y-auto font-mono text-sm'>
 				{logs.map((log, idx) => (

--- a/client/src/app/designer/page.jsx
+++ b/client/src/app/designer/page.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import ThemeToggle from "@/components/ThemeToggle";
 
 const palette = [
 	{ type: "button", label: "Button" },
@@ -81,7 +80,6 @@ export default function DesignerPage() {
 
 	return (
 		<div className='min-h-screen flex bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100'>
-			<ThemeToggle />
 			<div className='w-1/4 border-r p-4 space-y-2 bg-gray-50 dark:bg-gray-800'>
 				<h2 className='font-bold mb-4'>Components</h2>
 				{palette.map((p) => (

--- a/client/src/app/viewer/page.jsx
+++ b/client/src/app/viewer/page.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import ThemeToggle from "@/components/ThemeToggle";
 import apiService from "@/lib/api";
 
 const renderItem = (item) => {
@@ -49,7 +48,6 @@ export default function ViewerPage() {
 
 	return (
 		<div className='min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 relative'>
-			<ThemeToggle />
 			<div className='relative h-screen'>
 				{items.map((item) => (
 					<div

--- a/client/src/components/ThemeToggle.jsx
+++ b/client/src/components/ThemeToggle.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Sun, Moon } from "lucide-react";
 
 export default function ThemeToggle() {
 	const [dark, setDark] = useState(false);
@@ -21,8 +22,12 @@ export default function ThemeToggle() {
 	return (
 		<button
 			onClick={toggle}
-			className='absolute top-2 right-2 px-2 py-1 border rounded bg-white dark:bg-gray-800 dark:text-white'>
-			{dark ? "Light" : "Dark"}
+			aria-label='Toggle theme'
+			className='fixed top-2 right-2 p-2 rounded-full bg-white text-gray-900 dark:bg-gray-800 dark:text-gray-100 relative'>
+			<Sun className={`h-5 w-5 transition-all duration-500 ${dark ? "rotate-90 scale-0" : "rotate-0 scale-100"}`} />
+			<Moon
+				className={`absolute inset-0 m-auto h-5 w-5 transition-all duration-500 ${dark ? "rotate-0 scale-100" : "-rotate-90 scale-0"}`}
+			/>
 		</button>
 	);
 }


### PR DESCRIPTION
## Summary
- animate theme toggle with rotating sun/moon icons
- remove duplicate theme toggles from console, designer, and viewer pages

## Testing
- `npm test` (fails: Missing script: "test")
- `cd client && npm test` (fails: Missing script: "test")
- `cd client && npm run lint` (fails: ESLint couldn't find the config "next/javascript")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b10abaee7883209a1de9f46ab55476