### PR TITLE
feat: persist layout and extend esp32 lib

### DIFF
--- a/arduino/ZiLinkEsp32/examples/AllComponents/AllComponents.ino
+++ b/arduino/ZiLinkEsp32/examples/AllComponents/AllComponents.ino
@@ -1,0 +1,27 @@
+#include <WiFi.h>
+#include <ZiLinkEsp32.h>
+
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_PASSWORD";
+
+ZiLinkEsp32 zi;
+unsigned long lastSend = 0;
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+  zi.setupHttp("https://api.ziji.world", "device123", "token123");
+}
+
+void loop() {
+  if (millis() - lastSend > 5000) {
+    zi.createButton(false, "btn1");
+    zi.createSlider(20, "sld1");
+    zi.createToggle(true, "tgl1");
+    zi.createProgress(40, "prg1");
+    lastSend = millis();
+  }
+}

--- a/arduino/ZiLinkEsp32/examples/Button/Button.ino
+++ b/arduino/ZiLinkEsp32/examples/Button/Button.ino
@@ -1,0 +1,21 @@
+#include <WiFi.h>
+#include <ZiLinkEsp32.h>
+
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_PASSWORD";
+
+ZiLinkEsp32 zi;
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+
+  zi.setupHttp("https://api.ziji.world", "device123", "token123");
+  zi.createButton(false, "btn1");
+}
+
+void loop() {
+}

--- a/arduino/ZiLinkEsp32/examples/HttpData/HttpData.ino
+++ b/arduino/ZiLinkEsp32/examples/HttpData/HttpData.ino
@@ -1,0 +1,21 @@
+#include <WiFi.h>
+#include <ZiLinkEsp32.h>
+
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_PASSWORD";
+
+ZiLinkEsp32 zi;
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+
+  zi.setupHttp("https://api.ziji.world", "device123", "token123");
+  zi.sendData("{\"temp\":25}");
+}
+
+void loop() {
+}

--- a/arduino/ZiLinkEsp32/examples/HttpStatus/HttpStatus.ino
+++ b/arduino/ZiLinkEsp32/examples/HttpStatus/HttpStatus.ino
@@ -1,0 +1,21 @@
+#include <WiFi.h>
+#include <ZiLinkEsp32.h>
+
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_PASSWORD";
+
+ZiLinkEsp32 zi;
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+
+  zi.setupHttp("https://api.ziji.world", "device123", "token123");
+  zi.sendStatus("{\"online\":true}");
+}
+
+void loop() {
+}

--- a/arduino/ZiLinkEsp32/examples/MqttComponents/MqttComponents.ino
+++ b/arduino/ZiLinkEsp32/examples/MqttComponents/MqttComponents.ino
@@ -1,0 +1,26 @@
+#include <WiFi.h>
+#include <ZiLinkEsp32.h>
+
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_PASSWORD";
+
+ZiLinkEsp32 zi;
+unsigned long lastSend = 0;
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+  zi.setupMqtt("api.ziji.world", 1883, "device123", "token123");
+}
+
+void loop() {
+  zi.loop();
+  if (millis() - lastSend > 5000) {
+    zi.createButton(false, "btn1");
+    zi.createSlider(10, "sld1");
+    lastSend = millis();
+  }
+}

--- a/arduino/ZiLinkEsp32/examples/MqttData/MqttData.ino
+++ b/arduino/ZiLinkEsp32/examples/MqttData/MqttData.ino
@@ -1,0 +1,22 @@
+#include <WiFi.h>
+#include <ZiLinkEsp32.h>
+
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_PASSWORD";
+
+ZiLinkEsp32 zi;
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+
+  zi.setupMqtt("api.ziji.world", 1883, "device123", "token123");
+  zi.publishMqttData("{\"light\":300}");
+}
+
+void loop() {
+  zi.loop();
+}

--- a/arduino/ZiLinkEsp32/examples/Progress/Progress.ino
+++ b/arduino/ZiLinkEsp32/examples/Progress/Progress.ino
@@ -1,0 +1,21 @@
+#include <WiFi.h>
+#include <ZiLinkEsp32.h>
+
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_PASSWORD";
+
+ZiLinkEsp32 zi;
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+
+  zi.setupHttp("https://api.ziji.world", "device123", "token123");
+  zi.createProgress(75, "prg1");
+}
+
+void loop() {
+}

--- a/arduino/ZiLinkEsp32/examples/Slider/Slider.ino
+++ b/arduino/ZiLinkEsp32/examples/Slider/Slider.ino
@@ -1,0 +1,21 @@
+#include <WiFi.h>
+#include <ZiLinkEsp32.h>
+
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_PASSWORD";
+
+ZiLinkEsp32 zi;
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+
+  zi.setupHttp("https://api.ziji.world", "device123", "token123");
+  zi.createSlider(50, "sld1");
+}
+
+void loop() {
+}

--- a/arduino/ZiLinkEsp32/examples/Toggle/Toggle.ino
+++ b/arduino/ZiLinkEsp32/examples/Toggle/Toggle.ino
@@ -1,0 +1,21 @@
+#include <WiFi.h>
+#include <ZiLinkEsp32.h>
+
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_PASSWORD";
+
+ZiLinkEsp32 zi;
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+
+  zi.setupHttp("https://api.ziji.world", "device123", "token123");
+  zi.createToggle(true, "tgl1");
+}
+
+void loop() {
+}

--- a/arduino/ZiLinkEsp32/examples/WebSocketData/WebSocketData.ino
+++ b/arduino/ZiLinkEsp32/examples/WebSocketData/WebSocketData.ino
@@ -1,0 +1,22 @@
+#include <WiFi.h>
+#include <ZiLinkEsp32.h>
+
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_PASSWORD";
+
+ZiLinkEsp32 zi;
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+
+  zi.setupWebSocket("api.ziji.world", 80, "/ws", "device123", "token123");
+  zi.sendWebSocketData("{\"humidity\":60}");
+}
+
+void loop() {
+  zi.loop();
+}

--- a/arduino/ZiLinkEsp32/src/ZiLinkEsp32.cpp
+++ b/arduino/ZiLinkEsp32/src/ZiLinkEsp32.cpp
@@ -101,6 +101,18 @@ void ZiLinkEsp32::createSlider(int value, const char *id) {
         sendComponentData(payload);
 }
 
+void ZiLinkEsp32::createToggle(bool value, const char *id) {
+        String payload =
+            "{\"type\":\"toggle\",\"id\":\"" + String(id) + "\",\"value\":" + (value ? "true" : "false") + "}";
+        sendComponentData(payload);
+}
+
+void ZiLinkEsp32::createProgress(int value, const char *id) {
+        String payload =
+            "{\"type\":\"progress\",\"id\":\"" + String(id) + "\",\"value\":" + String(value) + "}";
+        sendComponentData(payload);
+}
+
 void ZiLinkEsp32::loop() {
         _ws.loop();
         _mqtt.loop();

--- a/arduino/ZiLinkEsp32/src/ZiLinkEsp32.h
+++ b/arduino/ZiLinkEsp32/src/ZiLinkEsp32.h
@@ -28,6 +28,8 @@ public:
         // Component helpers
         void createButton(bool value, const char *id);
         void createSlider(int value, const char *id);
+        void createToggle(bool value, const char *id);
+        void createProgress(int value, const char *id);
 
         void loop();
 

--- a/arduino/ZiLinkEsp32/src/ZiLinkEsp32.h
+++ b/arduino/ZiLinkEsp32/src/ZiLinkEsp32.h
@@ -10,7 +10,6 @@
 class ZiLinkEsp32 {
 public:
         ZiLinkEsp32();
-        void begin(const char *ssid, const char *password);
 
         // HTTP API
         void setupHttp(const char *baseUrl, const char *deviceId, const char *token);
@@ -26,10 +25,15 @@ public:
         bool publishMqttData(const String &payload);
         bool publishMqttStatus(const String &payload);
 
+        // Component helpers
+        void createButton(bool value, const char *id);
+        void createSlider(int value, const char *id);
+
         void loop();
 
 private:
         bool sendHttp(const String &endpoint, const String &payload);
+        bool sendComponentData(const String &payload);
 
         String _baseUrl;
         String _token;

--- a/client/src/app/designer/page.jsx
+++ b/client/src/app/designer/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import apiService from "@/lib/api";
 
 const palette = [
 	{ type: "button", label: "Button" },
@@ -13,14 +14,16 @@ export default function DesignerPage() {
 	const [items, setItems] = useState([]);
 
 	useEffect(() => {
-		const saved = localStorage.getItem("zilink-layout");
-		if (saved) {
-			setItems(JSON.parse(saved));
-		}
+		apiService
+			.getLayout()
+			.then((data) => setItems(data || []))
+			.catch(() => setItems([]));
 	}, []);
 
 	useEffect(() => {
-		localStorage.setItem("zilink-layout", JSON.stringify(items));
+		if (items.length >= 0) {
+			apiService.saveLayout(items);
+		}
 	}, [items]);
 
 	const handlePaletteDrag = (type) => (e) => {
@@ -101,6 +104,10 @@ export default function DesignerPage() {
 						key={item.id}
 						draggable
 						onDragStart={handleItemDrag(item.id)}
+						onContextMenu={(e) => {
+							e.preventDefault();
+							alert(`ID: ${item.id}`);
+						}}
 						className='absolute'
 						style={{ top: item.y, left: item.x }}>
 						{renderItem(item)}

--- a/client/src/app/viewer/page.jsx
+++ b/client/src/app/viewer/page.jsx
@@ -40,10 +40,10 @@ export default function ViewerPage() {
 	const [items, setItems] = useState([]);
 
 	useEffect(() => {
-		const saved = localStorage.getItem("zilink-layout");
-		if (saved) {
-			setItems(JSON.parse(saved));
-		}
+		apiService
+			.getLayout()
+			.then((data) => setItems(data || []))
+			.catch(() => setItems([]));
 	}, []);
 
 	return (

--- a/client/src/app/viewer/page.jsx
+++ b/client/src/app/viewer/page.jsx
@@ -10,8 +10,26 @@ const renderItem = (item) => {
 				<button
 					className='px-3 py-1 bg-blue-600 text-white rounded'
 					onClick={() => item.deviceId && apiService.sendCommand(item.deviceId, "toggle")}>
-					Button
+					{item.label}
 				</button>
+			);
+		case "toggle":
+			return (
+				<label className='flex items-center space-x-2'>
+					<input
+						type='checkbox'
+						onChange={(e) => item.deviceId && apiService.sendCommand(item.deviceId, e.target.checked ? "1" : "0")}
+					/>
+					<span>{item.label}</span>
+				</label>
+			);
+		case "progress":
+			return (
+				<progress
+					value='50'
+					max='100'
+					className='w-24'
+				/>
 			);
 		case "slider":
 			return (
@@ -23,12 +41,12 @@ const renderItem = (item) => {
 				/>
 			);
 		case "text":
-			return <p className='text-gray-800 dark:text-gray-200'>Text</p>;
+			return <p className='text-gray-800 dark:text-gray-200'>{item.label}</p>;
 		case "input":
 			return (
 				<input
 					className='border p-1 rounded'
-					placeholder='Input'
+					placeholder={item.label}
 				/>
 			);
 		default:

--- a/client/src/lib/api.js
+++ b/client/src/lib/api.js
@@ -453,6 +453,24 @@ class ApiService {
 	}
 
 	/**
+	 * Get saved UI layout
+	 * @returns {Promise<Array<Object>>}
+	 */
+	async getLayout() {
+		const response = await this.api.get("/api/users/layout");
+		return response.data.data;
+	}
+
+	/**
+	 * Save UI layout
+	 * @param {Array<Object>} layout
+	 * @returns {Promise<void>}
+	 */
+	async saveLayout(layout) {
+		await this.api.put("/api/users/layout", layout);
+	}
+
+	/**
 	 * Delete account
 	 * @param {string} [confirmPassword]
 	 * @returns {Promise<void>}

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -62,6 +62,10 @@ const userSchema = new mongoose.Schema(
 				default: "UTC",
 			},
 		},
+		layout: {
+			type: [mongoose.Schema.Types.Mixed],
+			default: [],
+		},
 		// Account status
 		isActive: {
 			type: Boolean,

--- a/server/src/routes/user.js
+++ b/server/src/routes/user.js
@@ -122,6 +122,31 @@ router.get("/dashboard", async (req, res) => {
 	}
 });
 
+// User layout routes
+router.get("/layout", (req, res) => {
+	res.json({
+		success: true,
+		data: req.user.layout || [],
+	});
+});
+
+router.put("/layout", async (req, res) => {
+	try {
+		req.user.layout = Array.isArray(req.body) ? req.body : [];
+		await req.user.save();
+		res.json({
+			success: true,
+			data: req.user.layout,
+		});
+	} catch (error) {
+		console.error("Update layout error:", error);
+		res.status(500).json({
+			success: false,
+			message: "Internal server error",
+		});
+	}
+});
+
 // Delete user account
 router.delete("/account", async (req, res) => {
 	try {


### PR DESCRIPTION
## Summary
- persist UI layout in user profile via new `/layout` API
- designer/viewer pages load and save layout through api and expose item IDs on right-click
- expand ESP32 helper with button/slider helpers and automatic transport selection while removing WiFi setup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find the config "next/javascript")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b20133e77c832087020feb1ca7c75a