### PR TITLE
feat: add device components endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"start:server": "cd server && npm start",
 		"start:client": "cd client && npm start",
 		"check": "prettier --ignore-path .gitignore --ignore-unknown --check .",
-		"format": "prettier --ignore-path .gitignore --ignore-unknown --write ."
+		"format": "prettier --ignore-path .gitignore --ignore-unknown --write .",
+		"test": "cd server && npm test"
 	},
 	"keywords": [
 		"iot",

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
 	"scripts": {
 		"dev": "nodemon src/index.js",
 		"start": "node src/index.js",
-		"build": "echo 'No build step needed for Node.js'"
+		"build": "echo 'No build step needed for Node.js'",
+		"test": "node --test"
 	},
 	"dependencies": {
 		"express": "^4.18.2",

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,10 +1,12 @@
 import "dotenv/config";
+import "./utils/logger.js";
 import express from "express";
 import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
 import rateLimit from "express-rate-limit";
 import fs from "node:fs";
+import path from "node:path";
 import { spawn } from "node:child_process";
 import { bin, install } from "cloudflared";
 import mongoose from "mongoose";
@@ -19,9 +21,12 @@ import { notFound } from "./middleware/notFound.js";
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+const isTest = process.env.NODE_ENV === "test";
 
 // Connect to MongoDB
-connectDB();
+if (!isTest) {
+	connectDB();
+}
 
 // Security middleware
 app.use(helmet());
@@ -75,9 +80,19 @@ app.use(cors(corsOptions));
 app.options("*", cors(corsOptions));
 
 // Logging
-if (process.env.NODE_ENV === "development") {
-	app.use(morgan("dev"));
+morgan.token("client-ip", (req) => req.headers["x-forwarded-for"]?.split(",")[0]?.trim() || req.ip);
+const logFormat = ":client-ip :method :url :status :res[content-length] - :response-time ms";
+
+const logsDir = path.resolve("logs");
+if (!fs.existsSync(logsDir)) {
+	fs.mkdirSync(logsDir, { recursive: true });
 }
+const accessLogStream = fs.createWriteStream(path.join(logsDir, "access.log"), {
+	flags: "a",
+});
+
+app.use(morgan(logFormat));
+app.use(morgan(logFormat, { stream: accessLogStream }));
 
 // Body parsing middleware
 app.use(express.json({ limit: "10mb" }));
@@ -102,59 +117,62 @@ app.use("/api/users", userRoutes);
 app.use(notFound);
 app.use(errorHandler);
 
-// Start the server
-const server = app.listen(PORT, () => {
-	console.log(`🚀 ZiLink Server is running on port ${PORT}`);
-	console.log(`📍 Environment: ${process.env.NODE_ENV}`);
-	console.log(`🔗 Client URL: ${process.env.CLIENT_URL}`);
-});
-
-// Initialize WebSocket server
-initWebSocketServer(server);
-console.log(`🔌 WebSocket server initialized on port ${PORT}`);
-
-// Initialize MQTT client
-initMQTTClient();
-console.log("📡 MQTT client initialized");
-
-// Ensure cloudflared binary is installed
-if (!fs.existsSync(bin)) {
-	await install(bin);
-}
-
-// Start Cloudflare tunnel if token is provided
-let cf = null;
-if (process.env.cloudflaredtoken) {
-	cf = spawn(bin, ["tunnel", "run", "--token", process.env.cloudflaredtoken], {
-		stdio: "inherit",
+let server;
+if (!isTest) {
+	// Start the server
+	server = app.listen(PORT, () => {
+		console.log(`🚀 ZiLink Server is running on port ${PORT}`);
+		console.log(`📍 Environment: ${process.env.NODE_ENV}`);
+		console.log(`🔗 Client URL: ${process.env.CLIENT_URL}`);
 	});
-} else {
-	console.log("⚠️  No cloudflared token provided, skipping tunnel setup");
-}
 
-const shutdown = async () => {
-	try {
-		cf?.kill();
-	} catch {}
+	// Initialize WebSocket server
+	initWebSocketServer(server);
+	console.log(`🔌 WebSocket server initialized on port ${PORT}`);
 
-	try {
-		await mongoose.connection.close();
-		console.log("🔒 MongoDB connection closed through app termination");
-	} catch (err) {
-		console.error("❌ Error closing MongoDB connection:", err);
+	// Initialize MQTT client
+	initMQTTClient();
+	console.log("📡 MQTT client initialized");
+
+	// Ensure cloudflared binary is installed
+	if (!fs.existsSync(bin)) {
+		await install(bin);
 	}
 
-	server.close(() => {
-		console.log("💤 Process terminated");
-		process.exit(0);
-	});
-};
+	// Start Cloudflare tunnel if token is provided
+	let cf = null;
+	if (process.env.cloudflaredtoken) {
+		cf = spawn(bin, ["tunnel", "run", "--token", process.env.cloudflaredtoken], {
+			stdio: "inherit",
+		});
+	} else {
+		console.log("⚠️  No cloudflared token provided, skipping tunnel setup");
+	}
 
-["SIGINT", "SIGTERM"].forEach((signal) => {
-	process.once(signal, () => {
-		console.log(`👋 ${signal} received, shutting down gracefully`);
-		shutdown();
+	const shutdown = async () => {
+		try {
+			cf?.kill();
+		} catch {}
+
+		try {
+			await mongoose.connection.close();
+			console.log("🔒 MongoDB connection closed through app termination");
+		} catch (err) {
+			console.error("❌ Error closing MongoDB connection:", err);
+		}
+
+		server.close(() => {
+			console.log("💤 Process terminated");
+			process.exit(0);
+		});
+	};
+
+	["SIGINT", "SIGTERM"].forEach((signal) => {
+		process.once(signal, () => {
+			console.log(`👋 ${signal} received, shutting down gracefully`);
+			shutdown();
+		});
 	});
-});
+}
 
 export default app;

--- a/server/src/models/Device.js
+++ b/server/src/models/Device.js
@@ -166,6 +166,24 @@ const deviceSchema = new mongoose.Schema(
 				},
 			},
 		},
+		// Device components
+		components: [
+			{
+				id: {
+					type: String,
+					required: true,
+				},
+				type: {
+					type: String,
+					required: true,
+				},
+				value: mongoose.Schema.Types.Mixed,
+				updatedAt: {
+					type: Date,
+					default: Date.now,
+				},
+			},
+		],
 		// Device status
 		status: {
 			isOnline: {

--- a/server/src/utils/logger.js
+++ b/server/src/utils/logger.js
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import path from "node:path";
+import util from "node:util";
+
+// Ensure logs directory exists
+const logDir = path.resolve("logs");
+if (!fs.existsSync(logDir)) {
+	fs.mkdirSync(logDir, { recursive: true });
+}
+
+const infoStream = fs.createWriteStream(path.join(logDir, "server.log"), {
+	flags: "a",
+});
+const errorStream = fs.createWriteStream(path.join(logDir, "error.log"), {
+	flags: "a",
+});
+
+function format(args) {
+	return util.format(...args);
+}
+
+const log = console.log;
+const error = console.error;
+
+console.log = (...args) => {
+	const message = `[${new Date().toISOString()}] ${format(args)}\n`;
+	infoStream.write(message);
+	log(message.trimEnd());
+};
+
+console.error = (...args) => {
+	const message = `[${new Date().toISOString()}] ${format(args)}\n`;
+	errorStream.write(message);
+	error(message.trimEnd());
+};
+
+export {}; // ensure module scope

--- a/server/test/deviceComponents.test.js
+++ b/server/test/deviceComponents.test.js
@@ -1,0 +1,89 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+
+process.env.NODE_ENV = "test";
+process.env.JWT_SECRET = "test-secret";
+process.env.GOOGLE_CLIENT_ID = "test";
+process.env.GOOGLE_CLIENT_SECRET = "test";
+process.env.GITHUB_CLIENT_ID = "test";
+process.env.GITHUB_CLIENT_SECRET = "test";
+process.env.DISCORD_CLIENT_ID = "test";
+process.env.DISCORD_CLIENT_SECRET = "test";
+
+const { default: app } = await import("../src/index.js");
+const { default: Device } = await import("../src/models/Device.js");
+const { wsManager } = await import("../src/services/websocket.js");
+
+const startServer = () =>
+	new Promise((resolve) => {
+		const s = app.listen(0, () => resolve(s));
+	});
+
+const makeToken = (deviceId, userId = "user1") => jwt.sign({ deviceId, userId }, process.env.JWT_SECRET);
+
+test("POST /api/devices/:id/components returns 404 when device missing", async () => {
+	const server = await startServer();
+	const port = server.address().port;
+
+	mock.method(Device, "findOne", async () => null);
+	mock.method(wsManager, "broadcastToWebClients", () => {});
+
+	const deviceId = "dev1";
+	const res = await fetch(`http://127.0.0.1:${port}/api/devices/${deviceId}/components`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${makeToken(deviceId)}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ type: "sensor", id: "temp", value: 42 }),
+	});
+	const body = await res.json();
+
+	assert.equal(res.status, 404);
+	assert.equal(body.message, "Device not found");
+
+	mock.restoreAll();
+	server.close();
+});
+
+test("POST /api/devices/:id/components saves component data", async () => {
+	const server = await startServer();
+	const port = server.address().port;
+
+	const deviceId = "dev2";
+	const fakeDevice = {
+		deviceId,
+		owner: "user1",
+		components: [],
+		save: async function () {
+			this.saved = true;
+		},
+	};
+
+	mock.method(Device, "findOne", async () => fakeDevice);
+	mock.method(wsManager, "broadcastToWebClients", () => {});
+
+	const res = await fetch(`http://127.0.0.1:${port}/api/devices/${deviceId}/components`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${makeToken(deviceId)}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ type: "sensor", id: "temp", value: 42 }),
+	});
+	const body = await res.json();
+
+	assert.equal(res.status, 201);
+	assert.equal(body.success, true);
+	assert.equal(fakeDevice.components.length, 1);
+	const c = fakeDevice.components[0];
+	assert.equal(c.id, "temp");
+	assert.equal(c.type, "sensor");
+	assert.equal(c.value, 42);
+	assert.ok(c.updatedAt instanceof Date);
+	assert.equal(fakeDevice.saved, true);
+
+	mock.restoreAll();
+	server.close();
+});

--- a/server/test/health.test.js
+++ b/server/test/health.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.NODE_ENV = "test";
+process.env.JWT_SECRET = "test-secret";
+process.env.GOOGLE_CLIENT_ID = "test";
+process.env.GOOGLE_CLIENT_SECRET = "test";
+process.env.GITHUB_CLIENT_ID = "test";
+process.env.GITHUB_CLIENT_SECRET = "test";
+process.env.DISCORD_CLIENT_ID = "test";
+process.env.DISCORD_CLIENT_SECRET = "test";
+
+const { default: app } = await import("../src/index.js");
+
+const startServer = () =>
+	new Promise((resolve) => {
+		const s = app.listen(0, () => resolve(s));
+	});
+
+test("GET /health returns OK", async () => {
+	const server = await startServer();
+	const port = server.address().port;
+	const res = await fetch(`http://127.0.0.1:${port}/health`);
+	const body = await res.json();
+	assert.equal(res.status, 200);
+	assert.equal(body.status, "OK");
+	server.close();
+});


### PR DESCRIPTION
## Summary
- track components on devices via new components field
- accept component updates through `POST /devices/:deviceId/components`
- log request IP addresses using custom morgan middleware and device route logs
- persist server logs and access logs to files for easier debugging
- add `npm test` scripts with a basic Node.js test
- add tests for server health check and component updates
- avoid starting the server or connecting to MongoDB when running tests

## Testing
- `npx prettier server/src/index.js server/test/deviceComponents.test.js server/test/health.test.js server/package.json package.json --check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d83e52748320a2c230f4b14e90db