### PR TITLE
refactor: encapsulate server in event-emitting class

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -10,6 +10,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { bin, install } from "cloudflared";
 import mongoose from "mongoose";
+import { EventEmitter } from "node:events";
 import connectDB from "./config/database.js";
 import authRoutes from "./routes/auth.js";
 import deviceRoutes from "./routes/device.js";
@@ -19,166 +20,204 @@ import { initMQTTServer, mqttServer } from "./services/mqttServer.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { notFound } from "./middleware/notFound.js";
 
-const app = express();
-const PORT = process.env.PORT || 3001;
-const isTest = process.env.NODE_ENV === "test";
+/**
+ * ZiLink server wrapper implemented as an {@link EventEmitter}.
+ * The class encapsulates the Express app and related services
+ * such as WebSocket, MQTT and Cloudflare tunnel. Consumers can
+ * listen to server lifecycle events like `started` and `shutdown`.
+ */
+class ZiLinkServer extends EventEmitter {
+        constructor() {
+                super();
+                this.app = express();
+                this.port = process.env.PORT || 3001;
+                this.isTest = process.env.NODE_ENV === "test";
+                this.cf = null;
 
-// Connect to MongoDB
-if (!isTest) {
-	connectDB();
+                // Security middleware
+                this.app.use(helmet());
+
+                // Rate limiting
+                const limiter = rateLimit({
+                        windowMs: 15 * 60 * 1000, // 15 minutes
+                        max: 100, // limit each IP to 100 requests per windowMs
+                        message: "Too many requests from this IP, please try again later.",
+                });
+                this.app.use(limiter);
+
+                // CORS configuration
+                // Allow multiple origins via env (comma-separated) and default local dev
+                const rawAllowed = [
+                        process.env.CLIENT_URLS,
+                        process.env.CLIENT_URL,
+                        "http://localhost:3000",
+                        "http://127.0.0.1:3000",
+                        "https://ziji.world",
+                ].filter(Boolean);
+
+                const allowedOrigins = rawAllowed
+                        .flatMap((v) => v.split(","))
+                        .map((v) => v.trim())
+                        .filter((v) => v.length > 0);
+
+                const corsOptions = {
+                        origin: (origin, callback) => {
+                                // Allow non-browser or same-origin requests (no Origin header)
+                                if (!origin) return callback(null, true);
+
+                                // Exact match against allowed origins
+                                if (allowedOrigins.includes(origin)) return callback(null, true);
+
+                                // Optionally allow subdomains of ziji.world
+                                try {
+                                        const url = new URL(origin);
+                                        if (url.hostname.endsWith(".ziji.world")) return callback(null, true);
+                                } catch (_) {}
+
+                                return callback(new Error(`Not allowed by CORS: ${origin}`));
+                        },
+                        credentials: true,
+                        methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+                        allowedHeaders: ["Content-Type", "Authorization"],
+                        optionsSuccessStatus: 204,
+                };
+
+                this.app.use(cors(corsOptions));
+                this.app.options("*", cors(corsOptions));
+
+                // Logging
+                morgan.token(
+                        "client-ip",
+                        (req) => req.headers["x-forwarded-for"]?.split(",")[0]?.trim() || req.ip,
+                );
+                const logFormat =
+                        ":client-ip :method :url :status :res[content-length] - :response-time ms";
+
+                const logsDir = path.resolve("logs");
+                if (!fs.existsSync(logsDir)) {
+                        fs.mkdirSync(logsDir, { recursive: true });
+                }
+                const accessLogStream = fs.createWriteStream(path.join(logsDir, "access.log"), {
+                        flags: "a",
+                });
+
+                this.app.use(morgan(logFormat));
+                this.app.use(morgan(logFormat, { stream: accessLogStream }));
+
+                // Body parsing middleware
+                this.app.use(express.json({ limit: "10mb" }));
+                this.app.use(express.urlencoded({ extended: true, limit: "10mb" }));
+
+                // Health check endpoint
+                this.app.get("/health", (req, res) => {
+                        res.status(200).json({
+                                status: "OK",
+                                message: "ZiLink Server is running",
+                                timestamp: new Date().toISOString(),
+                                version: "1.0.0",
+                        });
+                });
+
+                // API Routes
+                this.app.use("/api/auth", authRoutes);
+                this.app.use("/api/devices", deviceRoutes);
+                this.app.use("/devices", deviceRoutes);
+                this.app.use("/api/users", userRoutes);
+
+                // Error handling middleware
+                this.app.use(notFound);
+                this.app.use(errorHandler);
+        }
+
+        async start(port = this.port) {
+                if (this.server) return this.server;
+
+                // Connect to MongoDB
+                if (!this.isTest) {
+                        connectDB();
+                }
+
+                this.server = this.app.listen(port, () => {
+                        console.log(`🚀 ZiLink Server is running on port ${port}`);
+                        console.log(`📍 Environment: ${process.env.NODE_ENV}`);
+                        console.log(`🔗 Client URL: ${process.env.CLIENT_URL}`);
+                        this.emit("started", port);
+                });
+
+                if (!this.isTest) {
+                        // Initialize WebSocket server
+                        initWebSocketServer(this.server);
+                        console.log(`🔌 WebSocket server initialized on port ${port}`);
+
+                        // Initialize MQTT server
+                        initMQTTServer();
+                        console.log("📡 MQTT server initialized");
+
+                        // Ensure cloudflared binary is installed
+                        if (!fs.existsSync(bin)) {
+                                await install(bin);
+                        }
+
+                        // Start Cloudflare tunnel if token is provided
+                        if (process.env.cloudflaredtoken) {
+                                this.cf = spawn(
+                                        bin,
+                                        ["tunnel", "run", "--token", process.env.cloudflaredtoken],
+                                        { stdio: "inherit" },
+                                );
+                        } else {
+                                console.log(
+                                        "⚠️  No cloudflared token provided, skipping tunnel setup",
+                                );
+                        }
+
+                        ["SIGINT", "SIGTERM"].forEach((signal) => {
+                                process.once(signal, () => {
+                                        console.log(
+                                                `👋 ${signal} received, shutting down gracefully`,
+                                        );
+                                        this.shutdown();
+                                });
+                        });
+                }
+
+                return this.server;
+        }
+
+        async shutdown() {
+                try {
+                        this.cf?.kill();
+                } catch {}
+
+                try {
+                        await mongoose.connection.close();
+                        console.log("🔒 MongoDB connection closed through app termination");
+                } catch (err) {
+                        console.error("❌ Error closing MongoDB connection:", err);
+                }
+
+                try {
+                        mqttServer.close();
+                        console.log("📡 MQTT server closed");
+                } catch {}
+
+                if (this.server) {
+                        await new Promise((resolve) =>
+                                this.server.close(() => {
+                                        console.log("💤 Process terminated");
+                                        this.emit("shutdown");
+                                        resolve();
+                                }),
+                        );
+                        this.server = null;
+                }
+        }
 }
 
-// Security middleware
-app.use(helmet());
-
-// Rate limiting
-const limiter = rateLimit({
-	windowMs: 15 * 60 * 1000, // 15 minutes
-	max: 100, // limit each IP to 100 requests per windowMs
-	message: "Too many requests from this IP, please try again later.",
-});
-app.use(limiter);
-
-// CORS configuration
-// Allow multiple origins via env (comma-separated) and default local dev
-const rawAllowed = [
-	process.env.CLIENT_URLS,
-	process.env.CLIENT_URL,
-	"http://localhost:3000",
-	"http://127.0.0.1:3000",
-	"https://ziji.world",
-].filter(Boolean);
-
-const allowedOrigins = rawAllowed
-	.flatMap((v) => v.split(","))
-	.map((v) => v.trim())
-	.filter((v) => v.length > 0);
-
-const corsOptions = {
-	origin: (origin, callback) => {
-		// Allow non-browser or same-origin requests (no Origin header)
-		if (!origin) return callback(null, true);
-
-		// Exact match against allowed origins
-		if (allowedOrigins.includes(origin)) return callback(null, true);
-
-		// Optionally allow subdomains of ziji.world
-		try {
-			const url = new URL(origin);
-			if (url.hostname.endsWith(".ziji.world")) return callback(null, true);
-		} catch (_) {}
-
-		return callback(new Error(`Not allowed by CORS: ${origin}`));
-	},
-	credentials: true,
-	methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-	allowedHeaders: ["Content-Type", "Authorization"],
-	optionsSuccessStatus: 204,
-};
-
-app.use(cors(corsOptions));
-app.options("*", cors(corsOptions));
-
-// Logging
-morgan.token("client-ip", (req) => req.headers["x-forwarded-for"]?.split(",")[0]?.trim() || req.ip);
-const logFormat = ":client-ip :method :url :status :res[content-length] - :response-time ms";
-
-const logsDir = path.resolve("logs");
-if (!fs.existsSync(logsDir)) {
-	fs.mkdirSync(logsDir, { recursive: true });
-}
-const accessLogStream = fs.createWriteStream(path.join(logsDir, "access.log"), {
-	flags: "a",
-});
-
-app.use(morgan(logFormat));
-app.use(morgan(logFormat, { stream: accessLogStream }));
-
-// Body parsing middleware
-app.use(express.json({ limit: "10mb" }));
-app.use(express.urlencoded({ extended: true, limit: "10mb" }));
-
-// Health check endpoint
-app.get("/health", (req, res) => {
-	res.status(200).json({
-		status: "OK",
-		message: "ZiLink Server is running",
-		timestamp: new Date().toISOString(),
-		version: "1.0.0",
-	});
-});
-
-// API Routes
-app.use("/api/auth", authRoutes);
-app.use("/api/devices", deviceRoutes);
-app.use("/devices", deviceRoutes);
-app.use("/api/users", userRoutes);
-
-// Error handling middleware
-app.use(notFound);
-app.use(errorHandler);
-
-let server;
-if (!isTest) {
-	// Start the server
-	server = app.listen(PORT, () => {
-		console.log(`🚀 ZiLink Server is running on port ${PORT}`);
-		console.log(`📍 Environment: ${process.env.NODE_ENV}`);
-		console.log(`🔗 Client URL: ${process.env.CLIENT_URL}`);
-	});
-
-	// Initialize WebSocket server
-	initWebSocketServer(server);
-	console.log(`🔌 WebSocket server initialized on port ${PORT}`);
-
-	// Initialize MQTT server
-	initMQTTServer();
-	console.log("📡 MQTT server initialized");
-
-	// Ensure cloudflared binary is installed
-	if (!fs.existsSync(bin)) {
-		await install(bin);
-	}
-
-	// Start Cloudflare tunnel if token is provided
-	let cf = null;
-	if (process.env.cloudflaredtoken) {
-		cf = spawn(bin, ["tunnel", "run", "--token", process.env.cloudflaredtoken], {
-			stdio: "inherit",
-		});
-	} else {
-		console.log("⚠️  No cloudflared token provided, skipping tunnel setup");
-	}
-
-	const shutdown = async () => {
-		try {
-			cf?.kill();
-		} catch {}
-
-		try {
-			await mongoose.connection.close();
-			console.log("🔒 MongoDB connection closed through app termination");
-		} catch (err) {
-			console.error("❌ Error closing MongoDB connection:", err);
-		}
-
-		try {
-			mqttServer.close();
-			console.log("📡 MQTT server closed");
-		} catch {}
-
-		server.close(() => {
-			console.log("💤 Process terminated");
-			process.exit(0);
-		});
-	};
-
-	["SIGINT", "SIGTERM"].forEach((signal) => {
-		process.once(signal, () => {
-			console.log(`👋 ${signal} received, shutting down gracefully`);
-			shutdown();
-		});
-	});
+const server = new ZiLinkServer();
+if (!server.isTest) {
+        await server.start();
 }
 
-export default app;
+export const app = server.app;
+export default server;

--- a/server/test/deviceComponents.test.js
+++ b/server/test/deviceComponents.test.js
@@ -11,20 +11,17 @@ process.env.GITHUB_CLIENT_SECRET = "test";
 process.env.DISCORD_CLIENT_ID = "test";
 process.env.DISCORD_CLIENT_SECRET = "test";
 
-const { default: app } = await import("../src/index.js");
+const { default: server } = await import("../src/index.js");
 const { default: Device } = await import("../src/models/Device.js");
 const { wsManager } = await import("../src/services/websocket.js");
 
-const startServer = () =>
-	new Promise((resolve) => {
-		const s = app.listen(0, () => resolve(s));
-	});
+const startServer = () => server.start(0);
 
 const makeToken = (deviceId, userId = "user1") => jwt.sign({ deviceId, userId }, process.env.JWT_SECRET);
 
 test("POST /api/devices/:id/components returns 404 when device missing", async () => {
-	const server = await startServer();
-	const port = server.address().port;
+        const httpServer = await startServer();
+        const port = httpServer.address().port;
 
 	mock.method(Device, "findOne", async () => null);
 	mock.method(wsManager, "broadcastToWebClients", () => {});
@@ -43,13 +40,13 @@ test("POST /api/devices/:id/components returns 404 when device missing", async (
 	assert.equal(res.status, 404);
 	assert.equal(body.message, "Device not found");
 
-	mock.restoreAll();
-	server.close();
+        mock.restoreAll();
+        await server.shutdown();
 });
 
 test("POST /api/devices/:id/components saves component data", async () => {
-	const server = await startServer();
-	const port = server.address().port;
+        const httpServer = await startServer();
+        const port = httpServer.address().port;
 
 	const deviceId = "dev2";
 	const fakeDevice = {
@@ -84,13 +81,13 @@ test("POST /api/devices/:id/components saves component data", async () => {
 	assert.ok(c.updatedAt instanceof Date);
 	assert.equal(fakeDevice.saved, true);
 
-	mock.restoreAll();
-	server.close();
+        mock.restoreAll();
+        await server.shutdown();
 });
 
 test("POST /devices/:id/components saves component data", async () => {
-	const server = await startServer();
-	const port = server.address().port;
+        const httpServer = await startServer();
+        const port = httpServer.address().port;
 
 	const deviceId = "dev3";
 	const fakeDevice = {
@@ -125,13 +122,13 @@ test("POST /devices/:id/components saves component data", async () => {
 	assert.ok(c.updatedAt instanceof Date);
 	assert.equal(fakeDevice.saved, true);
 
-	mock.restoreAll();
-	server.close();
+        mock.restoreAll();
+        await server.shutdown();
 });
 
 test("POST /devices/:id/components works without token", async () => {
-	const server = await startServer();
-	const port = server.address().port;
+        const httpServer = await startServer();
+        const port = httpServer.address().port;
 
 	const deviceId = "dev4";
 	const fakeDevice = {
@@ -157,6 +154,6 @@ test("POST /devices/:id/components works without token", async () => {
 	assert.equal(fakeDevice.components.length, 1);
 	assert.equal(fakeDevice.saved, true);
 
-	mock.restoreAll();
-	server.close();
+        mock.restoreAll();
+        await server.shutdown();
 });

--- a/server/test/health.test.js
+++ b/server/test/health.test.js
@@ -10,19 +10,16 @@ process.env.GITHUB_CLIENT_SECRET = "test";
 process.env.DISCORD_CLIENT_ID = "test";
 process.env.DISCORD_CLIENT_SECRET = "test";
 
-const { default: app } = await import("../src/index.js");
+const { default: server } = await import("../src/index.js");
 
-const startServer = () =>
-	new Promise((resolve) => {
-		const s = app.listen(0, () => resolve(s));
-	});
+const startServer = () => server.start(0);
 
 test("GET /health returns OK", async () => {
-	const server = await startServer();
-	const port = server.address().port;
-	const res = await fetch(`http://127.0.0.1:${port}/health`);
-	const body = await res.json();
-	assert.equal(res.status, 200);
-	assert.equal(body.status, "OK");
-	server.close();
+        const httpServer = await startServer();
+        const port = httpServer.address().port;
+        const res = await fetch(`http://127.0.0.1:${port}/health`);
+        const body = await res.json();
+        assert.equal(res.status, 200);
+        assert.equal(body.status, "OK");
+        await server.shutdown();
 });


### PR DESCRIPTION
## Summary
- refactor server setup into `ZiLinkServer` class extending `EventEmitter`
- expose `start` and `shutdown` lifecycle methods for easier control in tests and runtime
- update tests to use new server API

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30d39d7c483209607e95c423a724c